### PR TITLE
251: Configure linting, formatting and typechecking

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+#
+# Install this using:
+# ln -s ../../.github/hooks/pre-commit .git/hooks/pre-commit
+#
+
+DART_FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.dart" | sed 's| |\\ |g')
+
+if [ ! -z "$DART_FILES" ]; then
+  if [ ! -x "$(command -v fvm)" ]; then
+    echo "You need to install fvm in order to commit and format files"
+    exit 1
+  fi
+
+  # Prettify all selected files
+  echo "$DART_FILES" | xargs fvm dart format -l 120
+
+  # Add back the modified/prettified files to staging
+  echo "$DART_FILES" | xargs git add
+fi

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="Dart">
+      <option name="RIGHT_MARGIN" value="120" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,28 +1,20 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at https://dart.dev/lints.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+analyzer:
+  exclude: [build/**]
+  errors:
+    always_use_package_imports: error
+    directives_ordering: error
+    prefer_single_quotes: error
+    require_trailing_commas: error
+  language:
+    strict-casts: true
+    strict-raw-types: true
+    strict-inference: true
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:
+    - always_use_package_imports
+    - directives_ordering
+    - prefer_single_quotes
+    - require_trailing_commas

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,7 +5,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "format": "fvm dart format -l 120 .",
+    "analyze": "fvm dart analyze",
+    "fix": "fvm dart fix --apply",
+    "fix:dry": "fvm dart fix --dry-run"
+  }
+}


### PR DESCRIPTION
### Short description

<!-- Describe this PR in one or two sentences. -->
Configure linting, formatting and typechecking and add linting rules.

### Proposed changes

<!-- Describe this PR in more detail. -->

- Change default line length to 120 chars for IntelliJ (TBD, let me know if you want to stick to the default 80. I find them rather short)
- Use `flutter_lints` linting config
- Add linting rules for single quotes, import sorting, package imports and trailing commas
- Enable strict typechecking

### Side effects

<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None.

### Testing

<!-- List all things that should be tested while reviewing this PR. -->
None.

### Resolved issues

<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #251.

---
