### PR TITLE
185: add first campaign screen

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "FSharp.suggestGitignore": false,
+    "cSpell.words": [
+        "gruene"
+    ],
+    "files.eol": "\n"
+}

--- a/assets/icons/refresh.svg
+++ b/assets/icons/refresh.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24">
+    <g fill="none" stroke="#ffffff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+        <path d="M20.5 8c-1.392-3.179-4.823-5-8.522-5C7.299 3 3.453 6.552 3 11.1"/>
+        <path d="M16.489 8.4h3.97A.54.54 0 0 0 21 7.86V3.9M3.5 16c1.392 3.179 4.823 5 8.522 5c4.679 0 8.525-3.552 8.978-8.1"/>
+        <path d="M7.511 15.6h-3.97a.54.54 0 0 0-.541.54v3.96"/>
+    </g>
+</svg>

--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/lib/app/theme/theme.dart
+++ b/lib/app/theme/theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class ThemeColors {
@@ -31,7 +32,7 @@ class ThemeColors {
 }
 
 class _ThemeTextStyles {
-  // TOOD use GrueneType font
+  // TODO use GrueneType font
   static TextStyle displayMedium = GoogleFonts.ptSans(
     textStyle: TextStyle(
       fontSize: 18,
@@ -78,12 +79,12 @@ final ThemeData appTheme = ThemeData.light().copyWith(
   primaryColor: ThemeColors.primary,
   disabledColor: ThemeColors.textDisabled,
   colorScheme: ThemeData.light().colorScheme.copyWith(
-    primary: ThemeColors.primary,
-    secondary: ThemeColors.secondary,
-    tertiary: ThemeColors.tertiary,
-    surface: ThemeColors.background,
-    surfaceDim: ThemeColors.backgroundSecondary,
-  ),
+        primary: ThemeColors.primary,
+        secondary: ThemeColors.secondary,
+        tertiary: ThemeColors.tertiary,
+        surface: ThemeColors.background,
+        surfaceDim: ThemeColors.backgroundSecondary,
+      ),
   textTheme: TextTheme(
     displayLarge: _ThemeTextStyles.displayLarge,
     displayMedium: _ThemeTextStyles.displayMedium,
@@ -101,4 +102,14 @@ final ThemeData appTheme = ThemeData.light().copyWith(
     unselectedLabelStyle: _ThemeTextStyles.labelSmall,
   ),
   scaffoldBackgroundColor: ThemeColors.backgroundSecondary,
+  actionIconTheme: ActionIconThemeData(
+    backButtonIconBuilder: (BuildContext context) => SvgPicture.asset('assets/icons/back.svg'),
+  ),
+  tabBarTheme: TabBarTheme(
+    indicatorColor: ThemeColors.primary,
+    indicatorSize: TabBarIndicatorSize.tab,
+    labelStyle: _ThemeTextStyles.titleMedium,
+    unselectedLabelStyle: _ThemeTextStyles.titleMedium,
+    labelColor: ThemeColors.primary,
+  ),
 );

--- a/lib/app/widgets/app_bar.dart
+++ b/lib/app/widgets/app_bar.dart
@@ -12,14 +12,28 @@ class MainAppBar extends StatelessWidget implements PreferredSizeWidget {
     final currentRoute = GoRouterState.of(context);
     final theme = Theme.of(context);
     return AppBar(
-      title: Text(currentRoute.name ?? '', style: theme.textTheme.displayMedium?.apply(color: theme.colorScheme.surface)),
+      title: Text(
+        currentRoute.name ?? '',
+        style: theme.textTheme.displayMedium?.apply(color: theme.colorScheme.surface),
+      ),
       foregroundColor: theme.colorScheme.surface,
       backgroundColor: theme.primaryColor,
       centerTitle: true,
       actions: [
+        if (currentRoute.path == Routes.campaigns)
+          IconButton(
+            icon: CustomIcon(
+              path: 'assets/icons/refresh.svg',
+              color: ThemeColors.background,
+            ),
+            onPressed: null,
+          ),
         if (currentRoute.path != Routes.settings)
           IconButton(
-            icon: CustomIcon(path: 'assets/icons/settings.svg', color: ThemeColors.background),
+            icon: CustomIcon(
+              path: 'assets/icons/settings.svg',
+              color: ThemeColors.background,
+            ),
             onPressed: () => context.push(Routes.settings),
           ),
       ],

--- a/lib/features/campaigns/screens/campaigns_screen.dart
+++ b/lib/features/campaigns/screens/campaigns_screen.dart
@@ -1,12 +1,93 @@
 import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/features/campaigns/screens/doors_screen.dart';
+import 'package:gruene_app/features/campaigns/screens/flyer_screen.dart';
+import 'package:gruene_app/features/campaigns/screens/posters_screen.dart';
+import 'package:gruene_app/features/campaigns/screens/statistics_screen.dart';
+import 'package:gruene_app/features/campaigns/screens/teams_screen.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
 
-class CampaignsScreen extends StatelessWidget {
-  const CampaignsScreen({super.key});
+class CampaignsScreen extends StatefulWidget {
+  CampaignsScreen({super.key});
+  @override
+  State<CampaignsScreen> createState() => _CampaignsScreen();
+}
+
+class _CampaignsScreen extends State<CampaignsScreen> with SingleTickerProviderStateMixin {
+  final List<CampaignMenuModel> campaignTabs = <CampaignMenuModel>[
+    CampaignMenuModel(t.campaigns.door.label, true, DoorsScreen()),
+    CampaignMenuModel(t.campaigns.posters.label, true, PostersScreen()),
+    CampaignMenuModel(t.campaigns.flyer.label, true, FlyerScreen()),
+    CampaignMenuModel(t.campaigns.team.label, false, TeamsScreen()),
+    CampaignMenuModel(t.campaigns.statistic.label, false, StatisticsScreen()),
+  ];
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    _tabController = TabController(length: campaignTabs.length, vsync: this);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _tabController.dispose();
+  }
+
+  void onTap(int index) {
+    setState(() {
+      _tabController.index = !campaignTabs[index]._enabled ? _tabController.previousIndex : index;
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('Campaigns Screen'),
+    return DefaultTabController(
+      initialIndex: 0,
+      length: campaignTabs.length,
+      child: Scaffold(
+        backgroundColor: ThemeColors.background,
+        appBar: AppBar(
+          shape: Border(bottom: BorderSide(color: ThemeColors.textLight, width: 2)),
+          toolbarHeight: 0,
+          backgroundColor: ThemeColors.backgroundSecondary,
+          bottom: TabBar(
+            controller: _tabController,
+            tabs: campaignTabs
+                .map(
+                  (CampaignMenuModel item) => Tab(
+                    child: Semantics(
+                      child: Text(
+                        item._tabTitle,
+                        style: item._enabled ? null : TextStyle(color: ThemeColors.textDisabled),
+                      ),
+                    ),
+                  ),
+                )
+                .toList(),
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
+            indicatorWeight: 4,
+            onTap: (int index) => onTap(index),
+          ),
+        ),
+        body: TabBarView(
+          controller: _tabController,
+          physics: NeverScrollableScrollPhysics(),
+          children: campaignTabs.map((CampaignMenuModel tab) {
+            return tab._view;
+          }).toList(),
+        ),
+      ),
     );
   }
+}
+
+class CampaignMenuModel {
+  final String _tabTitle;
+  final bool _enabled;
+  final Widget _view;
+
+  const CampaignMenuModel(this._tabTitle, this._enabled, this._view);
 }

--- a/lib/features/campaigns/screens/doors_screen.dart
+++ b/lib/features/campaigns/screens/doors_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/features/campaigns/widgets/filter_chip_widget.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class DoorsScreen extends StatelessWidget {
+  DoorsScreen({super.key});
+
+  final List<FilterChipModel> doorsFilter = [
+    FilterChipModel(t.campaigns.filters.visited_areas, false),
+    FilterChipModel(t.campaigns.filters.routes, false),
+    FilterChipModel(t.campaigns.filters.focusAreas, true),
+    FilterChipModel(t.campaigns.filters.experience_areas, false),
+  ];
+  final Map<String, List<String>> doorsExclusions = <String, List<String>>{
+    t.campaigns.filters.focusAreas: [t.campaigns.filters.visited_areas],
+    t.campaigns.filters.visited_areas: [t.campaigns.filters.focusAreas],
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        FilterChipCampaign(doorsFilter, doorsExclusions),
+        Center(child: Text(t.campaigns.door.label)),
+      ],
+    );
+  }
+}

--- a/lib/features/campaigns/screens/flyer_screen.dart
+++ b/lib/features/campaigns/screens/flyer_screen.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:gruene_app/features/campaigns/widgets/filter_chip_widget.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class FlyerScreen extends StatelessWidget {
+  FlyerScreen({super.key});
+
+  final List<FilterChipModel> flyerFilter = [
+    FilterChipModel(t.campaigns.filters.visited_areas, false),
+    FilterChipModel(t.campaigns.filters.routes, false),
+    FilterChipModel(t.campaigns.filters.experience_areas, false),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        FilterChipCampaign(flyerFilter, <String, List<String>>{}),
+        Center(child: Text(t.campaigns.flyer.label)),
+      ],
+    );
+  }
+}

--- a/lib/features/campaigns/screens/posters_screen.dart
+++ b/lib/features/campaigns/screens/posters_screen.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/widgets.dart';
+import 'package:gruene_app/features/campaigns/widgets/filter_chip_widget.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class PostersScreen extends StatelessWidget {
+  PostersScreen({super.key});
+
+  final List<FilterChipModel> postersFilter = [
+    FilterChipModel(t.campaigns.filters.routes, false),
+    FilterChipModel(t.campaigns.filters.polling_stations, false),
+    FilterChipModel(t.campaigns.filters.experience_areas, false),
+  ];
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        FilterChipCampaign(postersFilter, <String, List<String>>{}),
+        Center(child: Text(t.campaigns.posters.label)),
+      ],
+    );
+  }
+}

--- a/lib/features/campaigns/screens/statistics_screen.dart
+++ b/lib/features/campaigns/screens/statistics_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class StatisticsScreen extends StatelessWidget {
+  const StatisticsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Placeholder(
+      color: Colors.red,
+      child: Center(
+        child: Text(
+          t.campaigns.statistic.label,
+          style: TextStyle(fontSize: 20, color: ThemeColors.primary),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/campaigns/screens/teams_screen.dart
+++ b/lib/features/campaigns/screens/teams_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+import 'package:gruene_app/i18n/translations.g.dart';
+
+class TeamsScreen extends StatelessWidget {
+  const TeamsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Placeholder(
+      color: Colors.red,
+      child: Center(
+        child: Text(
+          t.campaigns.team.label,
+          style: TextStyle(fontSize: 20, color: ThemeColors.primary),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/campaigns/widgets/filter_chip_widget.dart
+++ b/lib/features/campaigns/widgets/filter_chip_widget.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:gruene_app/app/theme/theme.dart';
+
+class FilterChipModel {
+  final String _text;
+  final bool _isEnabled;
+
+  const FilterChipModel(this._text, this._isEnabled);
+}
+
+class FilterChipCampaign extends StatefulWidget {
+  final List<FilterChipModel> filterOptions;
+  final Map<String, List<String>> filterExclusions;
+
+  const FilterChipCampaign(
+    this.filterOptions,
+    this.filterExclusions, {
+    super.key,
+  });
+
+  @override
+  State<FilterChipCampaign> createState() => _FilterChipCampaignState();
+}
+
+class _FilterChipCampaignState extends State<FilterChipCampaign> {
+  Set<FilterChipModel> currentFilters = <FilterChipModel>{};
+
+  void unselect(String itemLabel) {
+    currentFilters.removeWhere((z) => z._text == itemLabel);
+  }
+
+  void unselectExclusions(FilterChipModel item) {
+    var filterExclusions = widget.filterExclusions;
+    filterExclusions.entries.where((x) => x.key == item._text).map((x) => x.value).forEach((x) => x.forEach(unselect));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Padding(
+        padding: EdgeInsets.only(left: 12),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Wrap(
+              spacing: 15.0,
+              children: widget.filterOptions.map((filterItem) {
+                return FilterChip(
+                  label: Text(filterItem._text),
+                  backgroundColor: ThemeColors.background,
+                  selectedColor: ThemeColors.primary,
+                  padding: EdgeInsets.zero,
+                  side: filterItem._isEnabled
+                      ? BorderSide(color: ThemeColors.primary, width: 2)
+                      : BorderSide(color: ThemeColors.textDisabled, width: 1),
+                  shape: StadiumBorder(),
+                  selected: currentFilters.contains(filterItem),
+                  showCheckmark: false,
+                  labelStyle: TextStyle(
+                    color: filterItem._isEnabled ? ChipLabelColor() : ThemeColors.textDisabled,
+                  ),
+                  onSelected: (bool selected) {
+                    setState(() {
+                      if (!filterItem._isEnabled) return;
+                      if (selected) {
+                        unselectExclusions(filterItem);
+                        currentFilters.add(filterItem);
+                      } else {
+                        currentFilters.remove(filterItem);
+                      }
+                    });
+                  },
+                );
+              }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ChipLabelColor extends Color implements WidgetStateColor {
+  const ChipLabelColor() : super(_default);
+
+  static const int _default = 0xFF000000;
+
+  @override
+  Color resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.selected)) {
+      return Colors.white; // Selected text color
+    }
+    return Colors.black; // normal text color
+  }
+}

--- a/lib/i18n/app_de.json
+++ b/lib/i18n/app_de.json
@@ -8,7 +8,29 @@
   },
   "campaigns": {
     "campaigns": "Wahlkampf",
-    "label": "Wahlkampf"
+    "label": "Wahlkampf",
+    "filters": {
+      "focusAreas": "Fokusgebiete",
+      "routes": "Routen",
+      "visited_areas": "Besuchte Gebiete",
+      "polling_stations": "Wahllokale",
+      "experience_areas": "Erfahrungsgebiete"
+    },
+    "posters": {
+      "label": "Plakate"
+    },
+    "door": {
+      "label": "Haustür"
+    },
+    "flyer": {
+      "label": "Flyer"
+    },
+    "team": {
+      "label": "Team"
+    },
+    "statistic": {
+      "label": "Statistik"
+    }
   },
   "profiles": {
     "profiles": "Mitglieder",


### PR DESCRIPTION
### Short description

Incorporate menu structures for campaign screen.

### Proposed changes

- new menu structure for campaign screen
- tabs for TEAMS and STATISTICS are disabled (as requested by PO)
- some sub-menu items are disabled (as requested by PO)
- menu items may differ from issue descriptions as these have not yet been updated (PO?)

### Side effects

- -

### Testing

<!-- List all things that should be tested while reviewing this PR. -->

### Resolved issues

- fixes #183 
- fixes #266 
- fixes #267 
- fixes #268 